### PR TITLE
Fix: Remove blocking await in WebSocket handler

### DIFF
--- a/example_python/main.py
+++ b/example_python/main.py
@@ -74,7 +74,7 @@ async def websocket_handler(request):
                     await asyncio.sleep(1 / sample_rate)
             
             task = asyncio.create_task(send_data())
-            await task
+            #await task
     except Exception as e:
         print(f"WebSocket error: {e}")
     finally:

--- a/example_python/main.py
+++ b/example_python/main.py
@@ -74,7 +74,7 @@ async def websocket_handler(request):
                     await asyncio.sleep(1 / sample_rate)
             
             task = asyncio.create_task(send_data())
-            #await task
+            
     except Exception as e:
         print(f"WebSocket error: {e}")
     finally:


### PR DESCRIPTION
Fixes #12

Removed `await task` that was blocking the WebSocket message processing loop after the first command. This allows multiple commands to be processed in the same WebSocket session without causing 1011 errors or connection issues.

The server now correctly handles the expected workflow where new commands stop previous data streams and start new ones.